### PR TITLE
Add call agenda clarification text to connect section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -314,6 +314,9 @@ const experience = [
                     Schedule a call<ExternalLinkIcon />
                 </a>
             </div>
+            <p class="text-sm text-gruvbox-light/70 dark:text-gruvbox-dark/70 mt-2">
+                (please mention 1-2 lines about your agenda - whether it's discussing AI projects, potential collaborations, or just tech conversations)
+            </p>
         </Section>
 
         <div class="text-sm text-gruvbox-light/70 dark:text-gruvbox-dark/70 -mt-10">


### PR DESCRIPTION
## Summary
Added clarification text below the "Schedule a call" link in the connect section to help visitors understand what to expect from the call.

## Changes
- Modified the "let's connect" section in `src/pages/index.astro` (the correct active file)
- Added a small text paragraph below the call scheduling links: "(please mention 1-2 lines about your agenda - whether it's discussing AI projects, potential collaborations, or just tech conversations)"
- Styled consistently with existing text using the same gruvbox color scheme and text size

## Why this change?
This helps visitors provide context when scheduling calls, making the conversations more productive and focused. The text appears as a helpful hint in the same casual tone as the rest of the page.

## Technical Details
- Used the correct active file (`src/pages/index.astro`) instead of the outdated MDX files
- Maintained consistent styling with `text-sm text-gruvbox-light/70 dark:text-gruvbox-dark/70`
- Added appropriate spacing with `mt-2` class
- Text appears naturally as part of the connect section flow